### PR TITLE
No subTagId bug

### DIFF
--- a/src/Library/EMVCoQR.php
+++ b/src/Library/EMVCoQR.php
@@ -35,7 +35,9 @@ class EMVCoQR
           foreach ($tag->subTags as $subTag) {
             if ($subTag->id == $subTagId) return $subTag;
           }
-        } else break;
+
+          return false;
+        }
 
         return $tag;
       }


### PR DESCRIPTION
Previously, when accessing main tag without any subtag passed: `$qr->getTagValue("01")`, the function will just return `false` which is incorrect. This is due to the break placement where if there's no subTagId passed then it'll exit the foreach which eventually go to the final `return false` statement.

In my PR, I "moved" the break statement into a `return false` if the searched subTagId is not found. However, if there's no subTagId passed, it'll return the parent tag correctly.

Ps. I've not checked the other library which may or may not have similar issue.